### PR TITLE
Fix: Update documentation link to point to main branch README

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis-landing",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "type": "module",
   "description": "Landing page for Terminal Jarvis - A unified command center for coding tools",
   "scripts": {

--- a/src/components/TerminalJarvisLanding.tsx
+++ b/src/components/TerminalJarvisLanding.tsx
@@ -629,7 +629,7 @@ export function TerminalJarvisLanding() {
           </div>
           <div className="flex justify-center space-x-responsive-md text-sm-responsive mb-responsive-sm">
             <a
-              href="https://github.com/BA-CalderonMorales/terminal-jarvis/tree/develop"
+              href="https://github.com/BA-CalderonMorales/terminal-jarvis/tree/main#terminal-jarvis"
               target="_blank"
               rel="noopener noreferrer"
               className="terminal-mono theme-text-secondary hover:theme-text-primary transition-colors"


### PR DESCRIPTION
 ## Summary
  - Fixed misleading documentation link that pointed to develop branch tree view (#7)
  - Updated link to point to main branch README with proper anchor
  - Bumped version to 0.0.11

  ## Changes
  - **Before**: <img width="1223" height="201" alt="doc-link-before" src="https://github.com/user-attachments/assets/4688e56d-833d-4f50-b7a0-0a9ccaefb377" />

  - **After**: 
<img width="491" height="52" alt="doc-link-after" src="https://github.com/user-attachments/assets/ab945260-7ddf-4d2e-a20d-e9c645ca8774" />


  ## Testing
  - Manual verification: Link now properly navigates to Terminal Jarvis documentation
  - CI checks passing (lint, build)
  - No tests required for simple URL change