### PR TITLE
Feature: add GitHub contribution links to footer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,20 +122,20 @@ Use conventional commits following [Semantic Versioning](https://semver.org/) wi
 
 ```bash
 # Examples:
-git commit -m "Fix: resolve mobile responsive layout issue"
-git commit -m "Feature: add new tool showcase animation"
-git commit -m "Docs: update development setup instructions"
-git commit -m "Style: improve typography and spacing consistency"
-git commit -m "Refactor: reorganize component structure for better maintainability"
+git commit -m "fix: resolve mobile responsive layout issue"
+git commit -m "feat: add new tool showcase animation"
+git commit -m "docs: update development setup instructions"
+git commit -m "style: improve typography and spacing consistency"
+git commit -m "refactor: reorganize component structure for better maintainability"
 
-# Prefixes: Feature, Fix, Docs, Style, Refactor, Test, Chore
+# Prefixes: feat, fix, docs, style, refactor, test, chore
 ```
 
 **Semantic Versioning**
-- `Feature:` minor version bump (1.0.0 → 1.1.0)
-- `Fix:` patch version bump (1.0.0 → 1.0.1)
+- `feat:` minor version bump (1.0.0 → 1.1.0)
+- `fix:` patch version bump (1.0.0 → 1.0.1)
 - `BREAKING CHANGE:` in commit body, major version bump (1.0.0 → 2.0.0)
-- Other prefixes (Docs, Style, Refactor, Test, Chore) may be patch bumps
+- Other prefixes (docs, style, refactor, test, chore) may be patch bumps
 
 **Note:** Follow these conventions for proper [semantic versioning](https://semver.org/) practices. While not yet automated, consistent commit messages help with manual version management and future automation plans.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,213 @@
+# Contributing to Terminal Jarvis Landing Page
+
+**Thank you for your interest in contributing to the Terminal Jarvis Landing Page!**
+
+This project is the frontend showcase for the Terminal Jarvis CLI tool, introducing developers to AI coding tools integration.
+
+## **FIRST STEP: Join Our Discord**
+
+**BEFORE opening any Pull Request**, please:
+
+**[Join Terminal Jarvis Discord](https://discord.gg/pZmQYExR)**
+
+## Contribution Types
+
+We welcome contributions. Add an issue if one doesn't exist and ask to be assigned. Suggestions are welcome in Discord before creating issues:
+
+### **Code Contributions**
+- UI/UX improvements and bug fixes
+- Performance optimizations
+- Responsive design enhancements
+- API integration improvements
+- Accessibility improvements
+
+### **Documentation**
+- README improvements
+- Setup and deployment guides
+- Code documentation and comments
+
+### **Design & Content**
+- Visual design improvements
+- Content accuracy and clarity
+- Typography and layout enhancements
+
+## **Bug Fix Process**
+
+Follow this general process **when applicable** (use judgment for simple changes like font sizes, color tweaks, or typo fixes):
+
+### **For Functional Bugs & Complex Issues:**
+
+1. **Make sure you are up to date on branch**
+   ```bash
+   git checkout development
+   git pull origin development
+   ```
+
+2. **Replicate bug**
+   - Document exact steps to reproduce
+   - Note expected vs actual behavior
+
+3. **If you can replicate, create feature branch**
+   ```bash
+   git checkout -b fix/my-specific-issue
+   ```
+
+4. **If you cannot replicate, document what you tried and talk with the dev team** (Brandon Calderon, Carlos Degante, Joshua Smith, or community in Discord `#bug-reporting` channel)
+
+5. **If you have a functional bug, create a failing test** (when applicable - not needed for simple styling changes)
+
+6. **Once you have a failing test, work on a fix. After you get a fix, create another test to keep track of expected behavior**
+
+7. **Run quality checks and fix errors until all clear**
+   ```bash
+   npm run lint
+   npm run type-check
+   npm run build
+   ```
+
+8. **Raise a PR against development branch**
+
+9. **Add reviewers as needed** - Brandon Calderon, Angel Vazquez, Carlos Degante, or Joshua Smith as reviewers when possible. Always get at least one review. 
+
+### **For Simple Changes:**
+- **Font sizes, colors, spacing, typos**: Skip the "create a failing test" steps, just make the change and document it well, screenshots if possible or video clips.
+
+- **Documentation updates**: Review for accuracy and clarity
+
+- **Content corrections**: Verify factual accuracy with Terminal Jarvis CLI
+
+## **Development Setup**
+
+### **Prerequisites**
+- Node.js (v18 or higher)
+- npm or yarn
+
+### **Getting Started**
+```bash
+# Fork the repository on GitHub
+git clone https://github.com/your-username/terminal-jarvis-landing.git
+cd terminal-jarvis-landing
+git checkout development
+
+# Install dependencies
+npm install
+
+# Start development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Preview production build
+npm run preview
+```
+
+## **Code Quality Standards**
+
+### **Frontend Code Requirements**
+- **TypeScript strict mode compliance**
+- **ESLint clean**: `npm run lint`
+- **Type checking**: `npm run type-check`
+- **Successful builds**: `npm run build`
+
+### **Project-Specific Standards**
+- **No emojis in code or commits** (per project guidelines)
+- **No unnecessary hyphens** unless required
+- **Professional documentation and comments**
+- **camelCase naming** (unless React components require PascalCase)
+- **No AI language remnants** in user-facing text
+
+### **Commit Message Standards**
+Use conventional commits following [Semantic Versioning](https://semver.org/) with Terminal Jarvis prefixes:
+
+```bash
+# Examples:
+git commit -m "Fix: resolve mobile responsive layout issue"
+git commit -m "Feature: add new tool showcase animation"
+git commit -m "Docs: update development setup instructions"
+git commit -m "Style: improve typography and spacing consistency"
+git commit -m "Refactor: reorganize component structure for better maintainability"
+
+# Prefixes: Feature, Fix, Docs, Style, Refactor, Test, Chore
+```
+
+**Semantic Versioning**
+- `Feature:` minor version bump (1.0.0 → 1.1.0)
+- `Fix:` patch version bump (1.0.0 → 1.0.1)
+- `BREAKING CHANGE:` in commit body, major version bump (1.0.0 → 2.0.0)
+- Other prefixes (Docs, Style, Refactor, Test, Chore) may be patch bumps
+
+**Note:** Follow these conventions for proper [semantic versioning](https://semver.org/) practices. While not yet automated, consistent commit messages help with manual version management and future automation plans.
+
+### **Testing Approach**
+
+**When testing is needed** (functional changes, API integration, complex components):
+- Write component tests for interactive elements
+- Test responsive behavior across devices
+- Verify accessibility compliance
+- Test API integration endpoints
+
+**When testing may not be needed** (simple visual changes):
+- Font size adjustments
+- Color scheme updates
+- Spacing and padding tweaks
+- Content text corrections
+
+## **Project Structure**
+
+```
+terminal-jarvis-landing/
+├── src/
+│   ├── api/                 # Terminal Jarvis API integration
+│   ├── components/          # React components
+│   ├── hooks/              # Custom React hooks
+│   ├── shared/             # Shared utilities and types
+│   └── styles/             # CSS and styling
+├── public/                 # Static assets
+├── docs/                   # Documentation
+├── CONTRIBUTING.md         # This file
+├── CLAUDE.md              # Project specifications
+└── package.json
+```
+
+## **Branch Strategy**
+
+- **`main`**: Production branch (GitHub Pages deployment)
+- **`development`**: Active development branch
+- **Feature branches**: `feature/description` or `fix/description`
+
+## **Integration with Terminal Jarvis CLI**
+
+This landing page showcases the main Terminal Jarvis CLI project. When making content changes:
+
+- **Verify accuracy** with the main CLI repository
+- **Maintain consistency** with CLI terminology and features
+- **Reference CLI documentation** for technical details
+- **Coordinate major changes** through Discord `#feature-requests` or `#general` channels
+
+
+## **Please, NONE of the following:**
+- emojis anywhere (code, commits, documentation)
+- force pushing to main or development branches
+- combining unrelated changes in one commit
+- vague commits like "fix stuff" or "update things"
+- breaking changes without Discord discussion
+- direct pushes to main branch
+
+## **Getting Help**
+
+- **Discord**: Real-time help in `#general` or `#bug-reporting` channels
+- **GitHub Issues**: Browse existing issues for contribution ideas
+- **README.md**: Project overview and setup instructions
+- **CLAUDE.md**: Comprehensive project specifications
+
+## **Useful Links**
+
+- **[Discord Community](https://discord.gg/pZmQYExR)** - Primary communication channel
+- **[Terminal Jarvis CLI](https://github.com/BA-CalderonMorales/terminal-jarvis)** - Main project repository
+
+---
+
+**Ready to contribute? Join our Discord community.**
+
+**Remember**: For simple changes like styling tweaks, feel free to skip the heavy testing process. For functional changes and new features, follow the full development workflow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis-landing",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "type": "module",
   "description": "Landing page for Terminal Jarvis - A unified command center for coding tools",
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -158,3 +158,13 @@ body {
   animation: loadingProgress 1.5s ease-in-out infinite;
   transform-origin: left center;
 }
+
+/* Terminal cursor blink animation */
+@keyframes blink {
+  0%, 50% {
+    opacity: 1;
+  }
+  51%, 100% {
+    opacity: 0;
+  }
+}

--- a/src/components/TerminalJarvisLanding.tsx
+++ b/src/components/TerminalJarvisLanding.tsx
@@ -627,7 +627,7 @@ export function TerminalJarvisLanding() {
           <div className="terminal-mono theme-text-secondary mb-responsive-sm text-base-responsive">
             BUILT BY THE TERMINAL JARVIS TEAM
           </div>
-          <div className="flex justify-center space-x-responsive-md text-sm-responsive mb-responsive-sm">
+          <div className="flex justify-center space-x-responsive-lg text-base-responsive mb-responsive-sm">
             <a
               href="https://github.com/BA-CalderonMorales/terminal-jarvis/tree/main#terminal-jarvis"
               target="_blank"
@@ -663,22 +663,45 @@ export function TerminalJarvisLanding() {
           </div>
           
           {/* Contribution Links */}
-          <div className="flex justify-center space-x-responsive-lg text-sm-responsive mb-responsive-sm">
+          <div className="flex justify-center space-x-8 text-base mb-responsive-sm">
             <a
               href="https://github.com/AngelCodes95/terminal-jarvis-landing/blob/development/CONTRIBUTING.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="terminal-mono font-semibold contribute-link"
+              className="terminal-mono font-semibold contribute-link flex items-center gap-2"
             >
-              CONTRIBUTE TO THIS LANDING PAGE
+              <svg 
+                width="16" 
+                height="16" 
+                viewBox="0 0 24 24" 
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>
+                <path d="M9 18c-4.51 2-5-2-7-2"/>
+              </svg>
+              CONTRIBUTE TO WEBSITE
             </a>
             <a
               href="https://github.com/BA-CalderonMorales/terminal-jarvis/blob/develop/docs/CONTRIBUTIONS.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="terminal-mono font-semibold contribute-cli-link"
+              className="terminal-mono font-semibold contribute-cli-link flex items-center gap-2"
             >
-              CONTRIBUTE TO TERMINAL JARVIS CLI
+              <span className="flex items-center">
+                &gt;
+                <span 
+                  className="w-2 h-4 bg-current"
+                  style={{
+                    animation: 'blink 1s step-end infinite'
+                  }}
+                >
+                </span>
+              </span>
+              CONTRIBUTE TO CLI
             </a>
           </div>
           {import.meta.env?.PROD === false && (

--- a/src/components/TerminalJarvisLanding.tsx
+++ b/src/components/TerminalJarvisLanding.tsx
@@ -661,6 +661,26 @@ export function TerminalJarvisLanding() {
               CRATES.IO
             </a>
           </div>
+          
+          {/* Contribution Links */}
+          <div className="flex justify-center space-x-responsive-lg text-sm-responsive mb-responsive-sm">
+            <a
+              href="https://github.com/AngelCodes95/terminal-jarvis-landing/blob/development/CONTRIBUTING.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="terminal-mono font-semibold contribute-link"
+            >
+              CONTRIBUTE TO THIS LANDING PAGE
+            </a>
+            <a
+              href="https://github.com/BA-CalderonMorales/terminal-jarvis/blob/develop/docs/CONTRIBUTIONS.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="terminal-mono font-semibold contribute-cli-link"
+            >
+              CONTRIBUTE TO TERMINAL JARVIS CLI
+            </a>
+          </div>
           {import.meta.env?.PROD === false && (
             <div className="text-center mb-responsive-sm">
               <div className="inline-block bg-yellow-900/20 border border-yellow-500/30 rounded px-3 py-1">

--- a/src/index.css
+++ b/src/index.css
@@ -308,6 +308,42 @@ body {
   }
 }
 
+/* Contribution Link Theme Variables */
+:root {
+  --contribute-color: #4ade80;
+  --contribute-color-hover: #22c55e;
+  --contribute-glow: rgba(74, 222, 128, 0.5);
+  --contribute-cli-glow: rgba(74, 222, 128, 0.8);
+}
+
+/* Contribution Link Styles */
+.contribute-link {
+  color: var(--contribute-color) !important;
+  transition: color 0.3s ease;
+}
+
+.contribute-link:hover {
+  color: var(--contribute-color-hover) !important;
+}
+
+.contribute-cli-link {
+  color: var(--contribute-color) !important;
+  text-shadow: 
+    0 0 10px var(--contribute-cli-glow),
+    0 0 20px var(--contribute-cli-glow),
+    0 0 30px var(--contribute-cli-glow);
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  transition: color 0.3s ease;
+}
+
+.contribute-cli-link:hover {
+  color: var(--contribute-color-hover) !important;
+}
+
+.light .contribute-cli-link {
+  font-weight: bold;
+}
+
 /* Legacy button styles for compatibility */
 a {
   font-weight: 500;

--- a/src/index.css
+++ b/src/index.css
@@ -312,8 +312,6 @@ body {
 :root {
   --contribute-color: #4ade80;
   --contribute-color-hover: #22c55e;
-  --contribute-glow: rgba(74, 222, 128, 0.5);
-  --contribute-cli-glow: rgba(74, 222, 128, 0.8);
 }
 
 /* Contribution Link Styles */
@@ -328,11 +326,6 @@ body {
 
 .contribute-cli-link {
   color: var(--contribute-color) !important;
-  text-shadow: 
-    0 0 10px var(--contribute-cli-glow),
-    0 0 20px var(--contribute-cli-glow),
-    0 0 30px var(--contribute-cli-glow);
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   transition: color 0.3s ease;
 }
 


### PR DESCRIPTION
 Summary

  Added GitHub contribution links to the landing page footer to improve community engagement and project accessibility.

  Changes

  - Footer Enhancement: Added two contribution links in the footer section
    - Link to landing page repository contribution guide
    - Link to Terminal Jarvis CLI contribution documentation
  - Contribution Documentation: Created CONTRIBUTING.md with development guidelines, setup instructions, and community standards in root of project
  - Styling Implementation: Added CSS theming for contribution links with hover effects and CLI-specific glow styling
  - Package Update: Minor version bump to reflect new community features per https://semver.org/

  Technical Details
  
  - Special glow effect for CLI contribution link using text-shadow
  - Both links open in new tabs with proper security attributes
  - Terminal monospace font styling maintains design consistency

  Test Plan Overview

  - Verified both contribution links navigate to correct repositories
  - Tested hover effects and styling in both light/dark themes
  - Confirm responsive layout on mobile and desktop
  - Validate new tab opening behavior

Sneak Peak

<img width="721" height="246" alt="tjl-contribute" src="https://github.com/user-attachments/assets/894b53e7-a172-41ce-8aad-ad2e8c5e01ab" />
<img width="714" height="239" alt="tjl-light-contribute" src="https://github.com/user-attachments/assets/d2cc4228-0c63-459e-a0c0-7e9e98226d87" />
